### PR TITLE
Remove the requirement of gpg signing for nodejs

### DIFF
--- a/cmd/brew-bootstrap-asdf
+++ b/cmd/brew-bootstrap-asdf
@@ -40,14 +40,6 @@ for plugin in $(cat .tool-versions | awk '{print $1}'); do
   fi
 done
 
-if [ ! -z "$(grep nodejs .tool-versions)" ]; then
-  brew bundle --file=- <<EOF
-brew "gpg"
-EOF
-
-  bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring
-fi
-
 asdf install
 
 if [ ! -z "$(grep ruby .tool-versions)" ]; then


### PR DESCRIPTION
The nodejs plugin is now using node-build and no longer needs to verify the sha of the install.
The `import-release-team-keyring` file no longer exists in the plugin

See https://github.com/asdf-vm/asdf-nodejs/pull/272 for more information