### PR TITLE
2022 update

### DIFF
--- a/cmd/brew-bootstrap-asdf
+++ b/cmd/brew-bootstrap-asdf
@@ -35,7 +35,7 @@ if [ ! -f .tool-versions ]; then
 fi
 
 for plugin in $(cat .tool-versions | awk '{print $1}'); do
-  if [ -z $(asdf plugin-list | grep $plugin) ]; then
+  if [ -z $(asdf plugin list | grep $plugin) ]; then
     asdf plugin add $plugin
   fi
 done

--- a/cmd/brew-bootstrap-asdf
+++ b/cmd/brew-bootstrap-asdf
@@ -31,7 +31,7 @@ if ! which asdf &>/dev/null; then
 fi
 
 if [ ! -f .tool-versions ]; then
-  abort "Error: you need a '.tool-versions' file to install packages"
+  abort "Error: you need a '.tool-versions' file to install packages!"
 fi
 
 for plugin in $(cat .tool-versions | awk '{print $1}'); do
@@ -41,6 +41,10 @@ for plugin in $(cat .tool-versions | awk '{print $1}'); do
 done
 
 asdf install
+
+for tool in $(cat .tool-versions); do
+  asdf shell $plugin
+done
 
 if [ ! -z "$(grep ruby .tool-versions)" ]; then
   (asdf which bundle &>/dev/null && bundle -v &>/dev/null) || {

--- a/cmd/brew-bootstrap-asdf
+++ b/cmd/brew-bootstrap-asdf
@@ -36,17 +36,9 @@ fi
 
 for plugin in $(cat .tool-versions | awk '{print $1}'); do
   if [ -z $(asdf plugin-list | grep $plugin) ]; then
-    asdf plugin-add $plugin
+    asdf plugin add $plugin
   fi
 done
-
-if [ ! -z "$(grep nodejs .tool-versions)" ]; then
-  brew bundle --file=- <<EOF
-brew "gpg"
-EOF
-
-  bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring
-fi
 
 asdf install
 

--- a/cmd/brew-bootstrap-asdf
+++ b/cmd/brew-bootstrap-asdf
@@ -42,10 +42,6 @@ done
 
 asdf install
 
-for tool in $(cat .tool-versions); do
-  asdf shell $plugin
-done
-
 if [ ! -z "$(grep ruby .tool-versions)" ]; then
   (asdf which bundle &>/dev/null && bundle -v &>/dev/null) || {
     gem install bundler

--- a/cmd/brew-bootstrap-developer-system
+++ b/cmd/brew-bootstrap-developer-system
@@ -2,7 +2,7 @@
 set -e
 
 # Setup shared dotfiles
-read -r -n 1 -p "Would you like install dotfiles (Y|n)?" answer
+read -r -n 1 -p "Would you like install dotfiles from https://github.com/cultureamp/web-team-dotfiles (Y/n)?" answer
 echo
 
 if [[ $answer =~ ^[Yy]$ ]]; then

--- a/cmd/brew-bootstrap-developer-system
+++ b/cmd/brew-bootstrap-developer-system
@@ -18,19 +18,15 @@ echo "OK"
 
 # Install standard homebrew packages
 echo "Installing standard homebrew packages…"
-brew bundle --file=- <<EOF
-brew "asdf"
-brew "gpg"
-EOF
+brew install asdf
 echo "OK"
 
 # Install/bootstrap standard asdf plugins
 echo "Installing standard asdf plugins…"
 if [ -z "$(asdf plugin-list | grep ruby)" ]; then
-  asdf plugin-add ruby
+  asdf plugin add ruby
 fi
 if [ -z "$(asdf plugin-list | grep nodejs)" ]; then
-  asdf plugin-add nodejs
+  asdf plugin add nodejs
 fi
-bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring
 echo "OK"

--- a/cmd/brew-bootstrap-developer-system
+++ b/cmd/brew-bootstrap-developer-system
@@ -2,19 +2,28 @@
 set -e
 
 # Setup shared dotfiles
-echo "Fetching cultureamp/web-team-dotfiles from GitHub…"
-if [ ! -d "$HOME/.dotfiles-web-team" ]; then
-  echo "Cloning to ~/.dotfiles-web-team:"
-  git clone $Q "https://github.com/cultureamp/web-team-dotfiles" ~/.dotfiles-web-team
+read -r -n 1 -p "Would you like install dotfiles (Y|n)?" answer
+echo
+
+if [[ $answer =~ ^[Yy]$ ]]; then
+  echo "Fetching cultureamp/web-team-dotfiles from GitHub…"
+  if [[ ! -d "$HOME/.dotfiles-web-team" ]]; then
+    echo "Cloning to ~/.dotfiles-web-team:"
+    git clone $Q "https://github.com/cultureamp/web-team-dotfiles" ~/.dotfiles-web-team
+  else
+    echo "Updating ~/.dotfiles-web-team"
+    (
+      cd ~/.dotfiles-web-team
+      git pull $Q --rebase --autostash
+    )
+  fi
+  cd ~/.dotfiles-web-team
+  ./script/setup
+  echo "OK"
 else
-  (
-    cd ~/.dotfiles-web-team
-    git pull $Q --rebase --autostash
-  )
+  echo "Skipping dotfile installation..."
+  echo "OK"
 fi
-cd ~/.dotfiles-web-team
-./script/setup
-echo "OK"
 
 # Install standard homebrew packages
 echo "Installing standard homebrew packages…"
@@ -23,10 +32,10 @@ echo "OK"
 
 # Install/bootstrap standard asdf plugins
 echo "Installing standard asdf plugins…"
-if [ -z "$(asdf plugin-list | grep ruby)" ]; then
+if [[ -z "$(asdf plugin list | grep ruby)" ]]; then
   asdf plugin add ruby
 fi
-if [ -z "$(asdf plugin-list | grep nodejs)" ]; then
+if [[ -z "$(asdf plugin list | grep nodejs)" ]]; then
   asdf plugin add nodejs
 fi
 echo "OK"


### PR DESCRIPTION
After trying to setup the cultureampcom repository, some changes to these brew scripts were required.

Notably, removing `import-release-team-keyring` was paramount. `asdf-nodejs` has removed that requirement as mentioned in the following links: 
- https://github.com/asdf-vm/asdf-nodejs/issues/325
- https://github.com/asdf-vm/asdf-nodejs/commit/a0ce61aed437187bda261f9940601d884a6be072
Consequently, we can remove the installation for `gpg` through `brew`.

In `bootstrap-asdf`, I have added a loop to also include the tools in the shell so it can be used by other scripts. This came from gem bundler not able to install the postgres gems because postgres was not set in the asdf shell.

In `bootstrap-developer-system`, I have added a user prompt if they want to install the dotfiles so they can do the dotfiles manually themselves.

Finally, I updated the syntax of the scripts and asdf commands to the current version.